### PR TITLE
feature/20-update-spacing-key

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,9 @@ module.exports = {
         "vue/mustache-interpolation-spacing": [
             "error",
             "always"
+        ],
+        "key-spacing": [
+            "error", { "beforeColon": false, "afterColon": true }
         ]
     },
     "parserOptions": {


### PR DESCRIPTION
close #20 - added key-spacing key

## Invalid
```json
{
    'foo':'bar'
}
```

## Valid
```json
{
    'foo': 'bar'
}
```

This rule forces a space after the colon `:`